### PR TITLE
Upgrade to the lastest PIA v.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.1]
+### Added
+- Upgrade support for old versions.
+- This file :)
+
+### Changed
+- Added new PIA CA cert.
+- Update PIA v.65
+
+## [1.0]
+- Original version which is a port of the Ubuntu script
+- Added Universal password

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PIA installer for Fedora
+# PIA installer for Fedora (UNOFFICIAL)
 
-Based on the Ubuntu installer from PIA. Automatically setup Private Internet Access VPN v65 for Fedora users.
+Automatically setup Private Internet Access VPN v65 for Fedora users. This is an UNOFICIAL installer that originally was based on the OFICIAL Ubuntu install script. Feel free to check the src.
 
 [Changelog](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PIA installer for Fedora (UNOFFICIAL)
 
-Automatically setup Private Internet Access VPN v65 for Fedora users. This is an UNOFICIAL installer that originally was based on the OFICIAL Ubuntu install script. Feel free to check the src.
+Automatically setup Private Internet Access VPN v65 for Fedora users. This is an UNOFICIAL installer that originally was based on the OFICCIAL Ubuntu install script. Feel free to check the src.
 
 [Changelog](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PIA installer for Fedora
 
-Based on the Ubuntu installer from PIA. Automatically setup Private Internet Access VPN v24 for Fedora users.
+Based on the Ubuntu installer from PIA. Automatically setup Private Internet Access VPN v65 for Fedora users.
+
+[Changelog](CHANGELOG.md).
 
 ## Versions supported.
 
@@ -15,10 +17,6 @@ _**NOTE**: this script uses dnf._
 
 ## Other distros
 "drhedberg" reported that the script also works with Opensuse 13.2 by replacing dnf with zypper.
-
-# Features supported
-* PIA version 24
-* Universal password
 
 # Install
 

--- a/install_fedora.sh
+++ b/install_fedora.sh
@@ -108,42 +108,19 @@ install_open_vpn( )
   fi
 }
 
-copy_crt( )
+install_crt( )
 {
-  echo 'Copying certificate..'
+  echo 'Downloading certificate..'
+  wget -O - https://www.privateinternetaccess.com/openvpn/openvpn.zip > /tmp/openvpn.zip
+  echo 'Installing certificate..'
   mkdir -p /etc/openvpn
-cat << EOF > /etc/openvpn/ca.crt
------BEGIN CERTIFICATE-----
-MIID2jCCA0OgAwIBAgIJAOtqMkR2JSXrMA0GCSqGSIb3DQEBBQUAMIGlMQswCQYD
-VQQGEwJVUzELMAkGA1UECBMCT0gxETAPBgNVBAcTCENvbHVtYnVzMSAwHgYDVQQK
-ExdQcml2YXRlIEludGVybmV0IEFjY2VzczEjMCEGA1UEAxMaUHJpdmF0ZSBJbnRl
-cm5ldCBBY2Nlc3MgQ0ExLzAtBgkqhkiG9w0BCQEWIHNlY3VyZUBwcml2YXRlaW50
-ZXJuZXRhY2Nlc3MuY29tMB4XDTEwMDgyMTE4MjU1NFoXDTIwMDgxODE4MjU1NFow
-gaUxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJPSDERMA8GA1UEBxMIQ29sdW1idXMx
-IDAeBgNVBAoTF1ByaXZhdGUgSW50ZXJuZXQgQWNjZXNzMSMwIQYDVQQDExpQcml2
-YXRlIEludGVybmV0IEFjY2VzcyBDQTEvMC0GCSqGSIb3DQEJARYgc2VjdXJlQHBy
-aXZhdGVpbnRlcm5ldGFjY2Vzcy5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJ
-AoGBAOlVlkHcxfN5HAswpryG7AN9CvcvVzcXvSEo91qAl/IE8H0knKZkIAhe/z3m
-hz0t91dBHh5yfqwrXlGiyilplVB9tfZohvcikGF3G6FFC9j40GKP0/d22JfR2vJt
-4/5JKRBlQc9wllswHZGmPVidQbU0YgoZl00bAySvkX/u1005AgMBAAGjggEOMIIB
-CjAdBgNVHQ4EFgQUl8qwY2t+GN0pa/wfq+YODsxgVQkwgdoGA1UdIwSB0jCBz4AU
-l8qwY2t+GN0pa/wfq+YODsxgVQmhgaukgagwgaUxCzAJBgNVBAYTAlVTMQswCQYD
-VQQIEwJPSDERMA8GA1UEBxMIQ29sdW1idXMxIDAeBgNVBAoTF1ByaXZhdGUgSW50
-ZXJuZXQgQWNjZXNzMSMwIQYDVQQDExpQcml2YXRlIEludGVybmV0IEFjY2VzcyBD
-QTEvMC0GCSqGSIb3DQEJARYgc2VjdXJlQHByaXZhdGVpbnRlcm5ldGFjY2Vzcy5j
-b22CCQDrajJEdiUl6zAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4GBAByH
-atXgZzjFO6qctQWwV31P4qLelZzYndoZ7olY8ANPxl7jlP3YmbE1RzSnWtID9Gge
-fsKHi1jAS9tNP2E+DCZiWcM/5Y7/XKS/6KvrPQT90nM5klK9LfNvS+kFabMmMBe2
-llQlzAzFiIfabACTQn84QLeLOActKhK8hFJy2Gy6
------END CERTIFICATE-----
-EOF
-
+  unzip -p /tmp/openvpn.zip ca.rsa.2048.crt > /etc/openvpn/ca.rsa.2048.crt
 }
 
 fix_conflict( )
 {
-  semanage fcontext -a -t home_cert_t /etc/openvpn/ca.crt
-  restorecon -R -v /etc/openvpn/ca.crt
+  semanage fcontext -a -t home_cert_t /etc/openvpn/ca.rsa.2048.crt
+  restorecon -R -v /etc/openvpn/ca.rsa.2048.crt
 }
 
 parse_server_info( )
@@ -184,7 +161,9 @@ comp-lzo=yes
 remote=$dns
 connection-type=password
 password-flags=0
-ca=/etc/openvpn/ca.crt
+ca=/etc/openvpn/ca.rsa.2048.crt
+cipher=AES-128-CBC
+port=1198
 
 [vpn-secrets]
 password=$PASS
@@ -231,7 +210,7 @@ verify_running_as_root
 install_python_version
 install_open_vpn
 read_user_login
-copy_crt
+install_crt
 fix_conflict
 parse_server_info
 write_config_files
@@ -239,4 +218,3 @@ restart_network_manager
 
 echo "Install successful!"
 exit 0
-

--- a/install_fedora.sh
+++ b/install_fedora.sh
@@ -201,7 +201,7 @@ restart_network_manager( )
 
 EXITCODE=0
 PROGRAM=`basename $0`
-VERSION=1.0
+VERSION=1.1
 
 while test $# -gt 0
 do


### PR DESCRIPTION
The main changes is to download the latest CRT from PIA instead of being inline. Also I've updated the VPN config for using that certificate (AES-128-CBC) and set the port to 1198.

If the installer is run over an old installation, i will be ask before trying to upgrade the configs. It may be a good idea to backup them ... you know, just in case ;)

